### PR TITLE
This commit sets the user/group of the uploaded war-file

### DIFF
--- a/manifests/war.pp
+++ b/manifests/war.pp
@@ -89,8 +89,12 @@ define tomcat::war(
       source         => $war_source,
       path           => "${_deployment_path}/${_war_name}",
       allow_insecure => $allow_insecure,
-      user           => $user,
-      group          => $group,
+    }
+    exec { "tomcat::war ${name}":
+      command     => "chown ${user}:${group} ${_deployment_path}/${_war_name}",
+      path        => $::facts['path'],
+      subscribe   => Archive["tomcat::war ${name}"],
+      refreshonly => true,
     }
   }
 }

--- a/spec/defines/war_spec.rb
+++ b/spec/defines/war_spec.rb
@@ -180,8 +180,6 @@ describe 'tomcat::war', :type => :define do
       'source'         => '/tmp/sample.war',
       'path'           => '/opt/apache-tomcat/webapps2/sample2.war',
       'allow_insecure' => true,
-      'user'           => 'tomcat',
-      'group'          => 'tomcat',
     )
     }
   end


### PR DESCRIPTION
The module archive only uses the $user/$group when unpacking
the file, not when only downloading the file (extract => false).